### PR TITLE
Draft: Support permissioned candymachines - Basic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/out
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
     "@headlessui/react": "^1.4.1",
+    "@identity.com/solana-gateway-ts": "^0.3.3",
     "@metaplex/js": "^1.1.1",
     "@project-serum/anchor": "0.17.1-beta.1",
     "@solana/spl-token": "^0.1.8",

--- a/src/components/recaptcha-button.tsx
+++ b/src/components/recaptcha-button.tsx
@@ -18,6 +18,7 @@ export const RecaptchaButton = ({
   const handleReCaptchaVerify = useCallback(async () => {
     if (!executeRecaptcha) {
       console.debug('Execute recaptcha not yet available');
+      await onClick()
       return;
     }
     setValidating(true)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,14 +10,16 @@ import useWalletBalance from '../hooks/use-wallet-balance';
 import { shortenAddress } from '../utils/candy-machine';
 import Countdown from 'react-countdown';
 import { RecaptchaButton } from '../components/recaptcha-button';
+import {faCheckCircle, faTimesCircle} from "@fortawesome/free-solid-svg-icons";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 const Home = () => {
   const [balance] = useWalletBalance()
   const [isActive, setIsActive] = useState(false);
   const wallet = useWallet();
 
-  const { isSoldOut, mintStartDate, isMinting, onMint, onMintMultiple, nftsData } = useCandyMachine()
-
+  const { isSoldOut, mintStartDate, isMinting, onMint, onMintMultiple, nftsData, walletPermissioned } = useCandyMachine()
+  
   return (
     <main className="p-5">
       <Toaster />
@@ -47,7 +49,14 @@ const Home = () => {
         </span>}
 
         {wallet.connected &&
-          <p className="text-gray-800 font-bold text-lg cursor-default">Address: {shortenAddress(wallet.publicKey?.toBase58() || "")}</p>
+          <div className="inline-flex" title={walletPermissioned ? 'Wallet is permitted to mint' : 'Wallet is not permitted to mint'}>
+            { walletPermissioned !== undefined && ( 
+              walletPermissioned ? 
+              <FontAwesomeIcon icon={faCheckCircle} className="w-4" color="green" /> : 
+              <FontAwesomeIcon icon={faTimesCircle} className="w-4" color="red" />
+            )}
+            <p className="text-gray-800 font-bold text-lg cursor-default">Address: {shortenAddress(wallet.publicKey?.toBase58() || "")}</p>
+          </div>
         }
 
         {wallet.connected &&
@@ -61,7 +70,8 @@ const Home = () => {
           {wallet.connected &&
             <RecaptchaButton
               actionName="mint"
-              disabled={isSoldOut || isMinting || !isActive}
+              // checking explicitly for walletPermissioned === false as undefined means "not needed"
+              disabled={isSoldOut || isMinting || !isActive || (walletPermissioned === false)}
               onClick={onMint}
             >
               {isSoldOut ? (
@@ -81,7 +91,8 @@ const Home = () => {
           {wallet.connected &&
             <RecaptchaButton
               actionName="mint5"
-              disabled={isSoldOut || isMinting || !isActive}
+              // checking explicitly for walletPermissioned === false as undefined means "not needed"
+              disabled={isSoldOut || isMinting || !isActive || (walletPermissioned === false)}  
               onClick={() => onMintMultiple(5)}
             >
               {isSoldOut ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,6 +282,15 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
+"@identity.com/solana-gateway-ts@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@identity.com/solana-gateway-ts/-/solana-gateway-ts-0.3.3.tgz#bb9ab03c57d39cd10f4a1f0a214e9b230f21cb91"
+  integrity sha512-lpFQZ8WDbPecorA0iNrsGVwPkkp1F4j56r51qKHEfARNKpeeRcNnutBfDxVVIWpV6oKL9yRPsbpwpa41tQ8YcQ==
+  dependencies:
+    "@solana/web3.js" "^1.22.0"
+    bn.js "^5.2.0"
+    borsh "^0.4.0"
+
 "@json-rpc-tools/provider@^1.5.5":
   version "1.7.6"
   resolved "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz"


### PR DESCRIPTION
Demonstrate how to integrate a UI with a permissioned candymachine using [this fork](https://github.com/metaplex-foundation/metaplex/pull/779).

TODO before merge - more testing to ensure backwards compatibility. Until the metaplex fork is merged, have a switch on the program ID, so that gated and non-gated candymachines are supported